### PR TITLE
Fix performance issue for named OleAutoArgs

### DIFF
--- a/lib/core/oleHelpers.inc
+++ b/lib/core/oleHelpers.inc
@@ -32,6 +32,7 @@ OleAutoArgs ::<-(OleAutoArgs x, Array ar) {
     if (argType == "int"   ) {int        s = (int        get(ar, 0,2)); put (x, argName, s); }
     if (argType == "bool"  ) {bool       s = (bool       get(ar, 0,2)); put (x, argName, s); }
     if (argType == "OLE"   ) {OleAutoObj s = (OleAutoObj get(ar, 0,2)); put (x, argName, s); }
+    delete ar
     return x; 
 }
 


### PR DESCRIPTION
Bug: After storing the content of named OLE automation arguments in the OleAutoArgs  object the related DOORS array is not deleted. This dramatically slows down code execution.